### PR TITLE
Use media queries instead of watching window width

### DIFF
--- a/css/dashboard/dashboard.css
+++ b/css/dashboard/dashboard.css
@@ -78,7 +78,7 @@
   ul.sidebar {
     position: absolute;
     top: 0;
-    bottom: 45px;
+    bottom: 0;
     padding: 0;
     margin: 0;
     list-style: none;
@@ -86,8 +86,10 @@
     overflow-x: hidden;
     overflow-y: auto;
   }
-  #page-wrapper:not(.active) ul.sidebar {
-    bottom: 0;
+  @media only screen and (min-width:992px){
+    #page-wrapper.expandable ul.sidebar {
+      bottom: 45px;
+    }
   }
   ul.sidebar li a {
     color: #fff;
@@ -114,14 +116,25 @@
     height: 35px;
     line-height: 40px;
     text-transform: uppercase;
-  }
-  #page-wrapper:not(.active) ul.sidebar .sidebar-title {
     display: none;
   }
-  #page-wrapper:not(.active) ul.sidebar .sidebar-title.separator {
+  @media only screen and (min-width:992px){
+    #page-wrapper.expandable ul.sidebar .sidebar-title {
+      display: block;
+    }
+  }
+  #page-wrapper ul.sidebar .sidebar-title.separator {
     display: block;
     height: 2px;
     margin: 13px 0;
+  }
+  @media only screen and (min-width:992px){
+    #page-wrapper.expandable ul.sidebar .sidebar-title.separator {
+      display: block;
+      height: auto;
+      margin: initial;
+      background: initial;
+    }
   }
   ul.sidebar .sidebar-list {
     height: 40px;
@@ -137,9 +150,15 @@
     border-left: 3px solid #e99d1a;
     text-indent: 22px;
   }
-  #page-wrapper:not(.active) ul.sidebar .sidebar-list a:hover span {
+  #page-wrapper ul.sidebar .sidebar-list a:hover span {
     border-left: 3px solid #e99d1a;
     text-indent: 22px;
+  }
+  @media only screen and (min-width:992px){
+    #page-wrapper.expandable ul.sidebar .sidebar-list a:hover span {
+      border-left: none;
+      text-indent: 25px;
+    }
   }
   ul.sidebar .sidebar-list .menu-icon {
     float: right;
@@ -158,9 +177,12 @@
     padding: 0;
     margin: 0;
     text-align: center;
-  }
-  #page-wrapper:not(.active) .sidebar-footer {
     display: none;
+  }
+  @media only screen and (min-width:992px){
+    #page-wrapper.expandable .sidebar-footer {
+      display: initial;
+    }
   }
   .sidebar-footer div a {
     color: #b2bfdc;
@@ -180,17 +202,19 @@
     height: auto;
   }
   @media only screen and (min-width:561px){
-    #page-wrapper.active {
+    #page-wrapper.expandable {
       padding-left: 250px;
     }
   }
-  @media only screen and (max-width:560px){
-    #page-wrapper.active {
+  @media only screen and (max-width:560px) and (min-width:992px){
+    #page-wrapper.expandable {
       padding-left: 70px;
     }
   }
-  #page-wrapper.active #sidebar-wrapper {
-    left: 150px;
+  @media only screen and (min-width:992px){
+    #page-wrapper.expandable #sidebar-wrapper {
+      left: 150px;
+    }
   }
 
 /* Header */

--- a/css/themes/blue.css
+++ b/css/themes/blue.css
@@ -1,7 +1,7 @@
 ul.sidebar .sidebar-main a,
 .sidebar-footer, 
 ul.sidebar .sidebar-list a:hover,
-#page-wrapper:not(.active) ul.sidebar .sidebar-title.separator {
+#page-wrapper ul.sidebar .sidebar-title.separator {
 	/* Sidebar header and footer color */
 	background: #273759;
 }

--- a/css/themes/green.css
+++ b/css/themes/green.css
@@ -1,7 +1,7 @@
 ul.sidebar .sidebar-main a,
 .sidebar-footer, 
 ul.sidebar .sidebar-list a:hover,
-#page-wrapper:not(.active) ul.sidebar .sidebar-title.separator {
+#page-wrapper ul.sidebar .sidebar-title.separator {
 	/* Sidebar header and footer color */
 	background: #2f5927;
 }

--- a/css/themes/red.css
+++ b/css/themes/red.css
@@ -1,7 +1,7 @@
 ul.sidebar .sidebar-main a,
 .sidebar-footer, 
 ul.sidebar .sidebar-list a:hover,
-#page-wrapper:not(.active) ul.sidebar .sidebar-title.separator {
+#page-wrapper ul.sidebar .sidebar-title.separator {
 	/* Sidebar header and footer color */
 	background: #592727;
 }

--- a/index.html
+++ b/index.html
@@ -22,14 +22,14 @@
 
 </head>
 <body ng-controller="MasterCtrl">
-  <div id="page-wrapper" ng-class="{'active': toggle}" ng-cloak>
+  <div id="page-wrapper" ng-class="{'expandable': expandableSideBar}" ng-cloak>
 
     <!-- Sidebar -->
 
     <div id="sidebar-wrapper">
       <ul class="sidebar">
         <li class="sidebar-main">
-          <a href="#" ng-click="toggleSidebar()">
+          <a href="#" ng-click="toggleExpandableSideBar()">
             Dashboard
             <span class="menu-icon glyphicon glyphicon-transfer"></span>
           </a>

--- a/js/angular/bootstrap.js
+++ b/js/angular/bootstrap.js
@@ -12,49 +12,18 @@ app.directive('loading', function () {
     }
 });
 
+/**
+ * Sidebar Toggle & Cookie Control
+ */
 app.controller('MasterCtrl', function($scope, $cookieStore) {
+    $scope.expandableSideBar = true;
 
-    /**
-     * Sidebar Toggle & Cookie Control
-     *
-     */
-    var mobileView = 992;
+    if(angular.isDefined($cookieStore.get('expandableSideBar'))) {
+        $scope.expandableSideBar = $cookieStore.get('expandableSideBar');
+    }
 
-    $scope.getWidth = function() { return window.innerWidth; };
-
-    $scope.$watch($scope.getWidth, function(newValue, oldValue)
-    {
-        if(newValue >= mobileView)
-        {
-            if(angular.isDefined($cookieStore.get('toggle')))
-            {
-                if($cookieStore.get('toggle') == false)
-                {
-                    $scope.toggle = false;
-                }            
-                else
-                {
-                    $scope.toggle = true;
-                }
-            }
-            else 
-            {
-                $scope.toggle = true;
-            }
-        }
-        else
-        {
-            $scope.toggle = false;
-        }
-
-    });
-
-    $scope.toggleSidebar = function() 
-    {
-        $scope.toggle = ! $scope.toggle;
-
-        $cookieStore.put('toggle', $scope.toggle);
+    $scope.toggleExpandableSideBar = function() {
+        $scope.expandableSideBar = ! $scope.expandableSideBar;
+        $cookieStore.put('expandableSideBar', $scope.expandableSideBar);
     };
-
-    window.onresize = function() { $scope.$apply(); };
 });


### PR DESCRIPTION
Allow CSS media queries to compute the style of the sidebar.
Make the CSS for the sidebar mobile first.
Rename `active` and related names to `expandable` to make the intended use clear.

Calling `$scope.$apply()` every time `window.innerWidth` changes will incur unnecessary recalculations.
As an app gets more complex this could become a performance issue.

Note: The media queries should probably be organized and located in a dedicated section, but they are currently added inline to conform to the existing code style.
