### PR TITLE
gulp deprecation warning

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,6 @@ gulp.task('compile-dashboard', function(){
 });
 
 gulp.task('watch', function() {
-  console.log('changed');
   gulp.watch('./less/**/*.less', ['compile-dashboard']);
 });
 


### PR DESCRIPTION
Nice dashboard :+1:

Built this on my machine and noticed that any changes to .less files are not live compiled into css.

This patch fixes the gulp deprecation warning and fixes the .less watch paths so any saved changes on the less files will be compiled into css.
