### PR TITLE
Fix unclosed rd-widget tag

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -97,7 +97,7 @@
 					</table>
         		</div>
 			</rd-widget-body>
-		<rd-widget>
+		</rd-widget>
 	</div>
 </div>
 


### PR DESCRIPTION
The rd-widget directive tag for Users widget at #100 was not closed.
