### PR TITLE
Use <uib-alert> instead of <alert> to work with recent version of ui-bootstrap

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,6 +1,6 @@
 <div class="row alerts-container" data-ng-controller="AlertsCtrl" data-ng-show="alerts.length">
   <div class="col-xs-12">
-    <alert data-ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)">{{alert.msg}}</alert>
+    <uib-alert data-ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)">{{alert.msg}}</uib-alert>
   </div>
 </div>
 


### PR DESCRIPTION
The alerts are not working correctly in the current master, this patch fixes that.